### PR TITLE
BOM4/5: Fix "0.5mm" inserts, and specify ⌀/height on magnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ AU: Unique Prints (https://uniqueprints.shop), PhaserFPV (https://www.phaserfpv.
 - 5x M3, 5 mm OD, 4 mm height heatset inserts (standard voron issue)
   - 2 for seating plenum to base
   - 2 for seating plenum lid to plenum
-- 8x ⌀6x3 mm cylindrical magnets
+- 8x ⌀6x3 mm round magnets
 - 1x 2 pin JST header
 - 4x M3x16 BHCS
   - for heat inserts that go into the four fan tabs
@@ -268,7 +268,8 @@ Optional for Vorons or any printer using 24PSU
 - 4x M3, 5mm OD, 4mm height Heatset inserts (standard voron issue)
   - 2 for seating plenum to base
   - 2 for seating plenum lid to plenum
-- 8x ⌀4x6 mm or ⌀6x3 mm cylindrical magnets
+- 8x ⌀4x6 mm or ⌀6x3 mm magnets
+  - Make sure to print correct parts (4x6 or 6x3 files)
 - 1x 2 pin JST header
 - 2x M3x10 SHCS
   - for seating plenum to base

--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ AU: Unique Prints (https://uniqueprints.shop), PhaserFPV (https://www.phaserfpv.
   - GDStime 6000rpm Dual Ball bearing on Aliexpress (This is 12V rated fans)
   - Delta BFB0524HH (This is 24V rated fans)
   - Avoid mechatronics fans for this purpose.
-- 5x M3x0.5mm Heatset inserts (standard voron issue)
+- 5x M3, 5 mm OD, 4 mm height heatset inserts (standard voron issue)
   - 2 for seating plenum to base
   - 2 for seating plenum lid to plenum
-- 8x 6x3mm cylindrical magnets
+- 8x ⌀6x3 mm cylindrical magnets
 - 1x 2 pin JST header
 - 4x M3x16 BHCS
   - for heat inserts that go into the four fan tabs
@@ -265,10 +265,10 @@ Optional for Vorons or any printer using 24PSU
 - 1x 5015 blowers (rating above 200Pa / 20mmH2O / 1 inH2O)
   - Sunon Maglev MF5015VX (high speed version, 6000 rpm. The 5000 rpm might be okay also)
   - or, the $4-6 GDStime 6000rpm Dual Ball bearing on Aliexpress
-- 4x Heatset inserts (M3x0.5mm, standard voron issue)
+- 4x M3, 5mm OD, 4mm height Heatset inserts (standard voron issue)
   - 2 for seating plenum to base
   - 2 for seating plenum lid to plenum
-- 8x 4x6 mm or 6x3 cylindrical magnets
+- 8x ⌀4x6 mm or ⌀6x3 mm cylindrical magnets
 - 1x 2 pin JST header
 - 2x M3x10 SHCS
   - for seating plenum to base

--- a/README.md
+++ b/README.md
@@ -230,9 +230,10 @@ AU: Unique Prints (https://uniqueprints.shop), PhaserFPV (https://www.phaserfpv.
   - GDStime 6000rpm Dual Ball bearing on Aliexpress (This is 12V rated fans)
   - Delta BFB0524HH (This is 24V rated fans)
   - Avoid mechatronics fans for this purpose.
-- 5x M3, 5 mm OD, 4 mm height heatset inserts (standard voron issue)
-  - 2 for seating plenum to base
-  - 2 for seating plenum lid to plenum
+- 6x M3, 5 mm OD, 4 mm height heatset inserts (standard voron issue)
+  - 1 in plenum base to secure plenum lid
+  - 1 in cartridge base to secure cartridge lide
+  - 4 in fans (2 in each fan × 2 fans)
 - 8x ⌀6x3 mm round magnets
 - 1x 2 pin JST header
 - 4x M3x16 BHCS


### PR DESCRIPTION
The heatset inserts is based on that 0.5mm is "wtf", and that 3x5x4 appears to be standard Voron issue. The magnet spesifics are based on measuring the holes in the cartridges of the different 3D models. I am still not sure about the "5x" heated inserts for the V5 BOM, since i belive 2+2=4, not 5, but i left it in for now.