### PR TITLE
Update V6 readme re: plenum printing

### DIFF
--- a/V6/README.md
+++ b/V6/README.md
@@ -49,6 +49,10 @@ Before installation, there are a few support pieces that need to be removed:
 
 ### Plenum
 
+#### Printing
+
+The plenum STL file includes two small pieces, which you will install into the plenum after printing.
+
 #### Electronics
 
 **Required:**


### PR DESCRIPTION
When printing, I thought I had broken off the two fan clamps that print with the plenum. This update to the readme will hopefully give an earlier warning that they are not meant to be attached during the print, but installed later.