### PR TITLE
Fix NOTES in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,11 @@ See the BOM below for more details.
 
 You're ready to build a Nevermore Micro? Cool!
 
-> **_NOTE:_** MADE FOR ABS/PC/PETG - USE A DECENTLY HEAT RESISTANT FILAMENT !!
+> [!NOTE]  
+> MADE FOR ABS/PC/PETG - USE A DECENTLY HEAT RESISTANT FILAMENT !!
 
-> **_NOTE:_**: Since you are committing to fan dissection, be aware a 5015 used for a NM Micro will most likely never find a different purpose!
+> [!NOTE]  
+>  Since you are committing to fan dissection, be aware a 5015 used for a NM Micro will most likely never find a different purpose!
 
 ## SOURCING THE PROPER ACID-FREE CARBON
 


### PR DESCRIPTION
The previous notes had an extra colon character; while fixing it I changed it to use GitHub's native admonitions. No hard feelings if you don't like it :)

before:
<img width="218" alt="Screenshot 2024-01-24 at 11 27 24" src="https://github.com/nevermore3d/Nevermore_Micro/assets/6930756/f8ff1bd1-7287-449b-896d-a92c7d54af45">

after:
<img width="356" alt="Screenshot 2024-01-24 at 11 28 41" src="https://github.com/nevermore3d/Nevermore_Micro/assets/6930756/b125cec2-b9a5-4b95-bed4-b48559965e7e">
